### PR TITLE
check if headers map is existing on options

### DIFF
--- a/lib/http_wrapper.js
+++ b/lib/http_wrapper.js
@@ -59,7 +59,7 @@ function wrapHttpCreateServer(config) {
 }
 
 function inject(options, headers) {
-  if (tracer.currentTrace) {
+  if (tracer.currentTrace && options.headers) {
     headers.forEach(header => {
       if (tracer.currentTrace.context.has(header)) {
         // eslint-disable-next-line no-param-reassign


### PR DESCRIPTION
hi,

Thanks for this really useful module ! 

I encountered the use case when a dependency module was doing some http requests and then the options.headers is not rpesent and it breaks. 
This little check makes it working