### PR TITLE
Support http.get(), different method signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,5 @@ Node's `async_hooks` module (new in Node 8) is used to set/reset `tracer.current
 ## Limitations
 
 - Only tested with `Express 4`
-- Only propagate headers if `http.request(options, cb)` is used with `options` as an `Object`.
 - Need Node >= 8
 - Many more....

--- a/lib/http_wrapper.js
+++ b/lib/http_wrapper.js
@@ -4,6 +4,7 @@ const tracer = require('./tracer');
 
 const originalHttpCreateServer = http.createServer;
 const originalRequest = http.request;
+const originalGet = http.get;
 
 function setAndCollectCorrelationId(config, req, res) {
   let correlationId = req.headers[config.correlationIdHeader];
@@ -74,11 +75,31 @@ function inject(options, headers) {
   }
 }
 
-function wrapHttpRequest(config) {
-  return function _wrappedHttpRequest(options, cb) {
+function wrapHttpRequest(originalMethod, config) {
+  function urlFirst(url, options, cb) {
     inject(options, config.headersToInject);
 
-    return originalRequest(options, cb);
+    return originalMethod(url, options, cb);
+  }
+
+  function optionsFirst(options, cb) {
+    inject(options, config.headersToInject);
+
+    return originalMethod(options, cb);
+  }
+
+  return function _wrappedHttpRequest(first, ...rest) {
+    if (typeof first === 'string') {
+      const [second] = rest;
+
+      if (typeof second === 'function') {
+        return urlFirst(first, {}, ...rest);
+      }
+
+      return urlFirst(first, ...rest);
+    }
+
+    return optionsFirst(first, ...rest);
   };
 }
 
@@ -86,7 +107,9 @@ function wrapHttp(config) { // args ([options<Object>])
   http.createServer__original = originalHttpCreateServer;
   http.createServer = wrapHttpCreateServer(config);
   http.request__original = originalRequest;
-  http.request = wrapHttpRequest(config);
+  http.request = wrapHttpRequest(originalRequest, config);
+  http.get__original = originalGet;
+  http.get = wrapHttpRequest(originalGet, config);
 }
 
 module.exports = { wrapHttp };

--- a/test/propagate_headers_with_express_url_parse.test.js
+++ b/test/propagate_headers_with_express_url_parse.test.js
@@ -13,6 +13,15 @@ hpropagate({
   ],
 });
 
+function majorVersion() {
+  const match = process.version.match(/^v(\d+)/);
+  if (match) {
+    return parseInt(match[1], 10);
+  }
+
+  return undefined;
+}
+
 // Simple Express app that makes a call to a outbound service
 // to prove that we propagate headers (using the request module)
 app.get('/', (req, res) => {
@@ -144,13 +153,16 @@ test('should propagate headers when parsing urls without headers', assert => {
 });
 
 test('should propagate headers similarly for all http.request and http.get method signatures', assert => {
-  const urlPaths = [
+  const urlPaths = majorVersion() >= 10 ? [
     '/',
     '/request/url-first',
     '/request/url-first/no-options',
     '/get/options-first',
     '/get/url-first',
     '/get/url-first/no-options',
+  ] : [
+    '/',
+    '/get/options-first',
   ];
 
   assert.plan(5 * urlPaths.length);


### PR DESCRIPTION
Currently `hpropagate` supports calls matching this signature:

    http.request(options[, callback])

This PR adds support and tests for additional signatures:

    http.request(url[, options][, callback]) // requires Node 10+
    http.get(options[, callback])
    http.get(url[, options][, callback])     // requires Node 10+

Hopefully this makes `hpropagate` slightly more consistent to use.